### PR TITLE
fix: add email validation and fix message stacking on auth page

### DIFF
--- a/frontend/src/app/pages/auth/auth.component.ts
+++ b/frontend/src/app/pages/auth/auth.component.ts
@@ -41,8 +41,14 @@ export class AuthComponent {
   error = signal<string | null>(null);
   message = signal<string | null>(null);
 
+  private static readonly EMAIL_PATTERN = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
   requestCode(): void {
     if (!this.email) {
+      return;
+    }
+    if (!AuthComponent.EMAIL_PATTERN.test(this.email)) {
+      this.error.set("Please enter a valid email address.");
       return;
     }
     this.loading.set(true);
@@ -70,6 +76,7 @@ export class AuthComponent {
 
     this.authService.verifyCode(this.email, this.code, this.isRegister).subscribe({
       error: (err) => {
+        this.message.set(null);
         this.error.set(this.getErrorDetail(err, "Invalid code."));
         this.loading.set(false);
       },


### PR DESCRIPTION
## Summary

Fixes two issues on the auth (login/register) page:

### Email validation (#23)
Previously, users could enter any string (e.g. "123") in the email field and the system would accept it. Now a basic email format validation (`user@domain.tld`) is performed client-side before sending the verification code request.

### Message stacking (#24)
When a user submitted an incorrect verification code, the error message would stack below the existing "Code sent" success message instead of replacing it. Now the success message is cleared whenever a verification error occurs.

Closes #23
Closes #24