### PR TITLE
fix: show valid default expiry for all user tiers

### DIFF
--- a/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -216,7 +216,12 @@ export class DashboardComponent implements OnInit {
           1,
           Math.ceil((new Date(ref.expires_at).getTime() - Date.now()) / (1000 * 60 * 60)),
         );
-        this.panelExpiryHours.set(hoursLeft > 0 ? hoursLeft : 168);
+        // Snap to the closest available expiry option so the dropdown shows a valid selection
+        const options = [1, 24, 72, 168, 336, 720];
+        const closest = options.reduce((prev, curr) =>
+          Math.abs(curr - hoursLeft) < Math.abs(prev - hoursLeft) ? curr : prev,
+        );
+        this.panelExpiryHours.set(closest);
         this.panelMaxDownloads.set(ref.max_downloads ?? 0);
         // Load download stats if group has an upload_group
         if (group.uploadGroup) {

--- a/frontend/src/app/pages/home/home.component.ts
+++ b/frontend/src/app/pages/home/home.component.ts
@@ -72,8 +72,8 @@ export class HomeComponent {
   popupAuthError = signal<string | null>(null);
 
   // Upload settings
-  /** Default 7 days */
-  expiryHours = signal(168);
+  /** Default 3 days (valid across all tiers) */
+  expiryHours = signal(72);
   /** 0 = unlimited */
   maxDownloads = signal(0);
   /** Whether the upload is publicly accessible. */


### PR DESCRIPTION
Closing in favor of PR #34 which supersedes all changes here (default expiry 72h + tier-aware expiry snapping + tier-based max download options).