### PR TITLE
fix: make upload result action buttons equal size

### DIFF
--- a/frontend/src/app/pages/home/home.component.scss
+++ b/frontend/src/app/pages/home/home.component.scss
@@ -166,7 +166,7 @@
 }
 
 .upload-another {
-  @apply mt-2;
+  /* no extra margin — contained in flex gap */
 }
 
 .result-file-list {
@@ -236,6 +236,11 @@ app-upload-settings {
 
 .result-actions {
   @apply flex gap-2 justify-center flex-wrap;
+
+  .btn {
+    @apply flex-1;
+    min-width: 0;
+  }
 }
 
 .popup-overlay {


### PR DESCRIPTION
## Summary

After uploading files, the "Go to Download Page" button was wider than the "Upload more files" button. Both buttons now share equal width via `flex-1` and the unnecessary `margin-top` on the secondary button is removed since the flex container already provides spacing via `gap`.

Closes #17