### PR TITLE
fix: show Save button for free users in dashboard

### DIFF
--- a/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -152,7 +152,7 @@ export class DashboardComponent implements OnInit {
   }
 
   canSave(): boolean {
-    return this.userTier() === "premium";
+    return this.userTier() !== "temporary";
   }
 
   hasUnsavedFiles(): boolean {


### PR DESCRIPTION
## Summary

The "Save" button for editing transfer settings in the dashboard was only visible to premium users. Free users could expand settings and change values but had no way to apply those changes.

Now all authenticated users (free and premium) see the Save button and can update their transfer settings.

Closes #22