### PR TITLE
fix: make plans/pricing page accessible without login

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -28,7 +28,6 @@ export const routes: Routes = [
     path: "dashboard",
   },
   {
-    canActivate: [authGuard],
     loadComponent: () =>
       import("./pages/premium/premium.component").then((m) => m.PremiumComponent),
     path: "premium",

--- a/frontend/src/app/components/header/header.component.html
+++ b/frontend/src/app/components/header/header.component.html
@@ -41,6 +41,8 @@
         @if (auth.authenticated()) {
           <a routerLink="/dashboard" class="nav-link" (click)="closeMenu()">Dashboard</a>
           <a routerLink="/premium" class="nav-link" (click)="closeMenu()">Account Tier</a>
+        } @else {
+          <a routerLink="/premium" class="nav-link" (click)="closeMenu()">Plans</a>
         }
         @if (isAdmin()) {
           <a routerLink="/admin" class="nav-link" (click)="closeMenu()">Admin</a>

--- a/frontend/src/app/pages/premium/premium.component.html
+++ b/frontend/src/app/pages/premium/premium.component.html
@@ -91,7 +91,11 @@
     </div>
 
     <div class="actions">
-      <a routerLink="/dashboard" class="btn btn-secondary">Back to Dashboard</a>
+      @if (isAuthenticated) {
+        <a routerLink="/dashboard" class="btn btn-secondary">Back to Dashboard</a>
+      } @else {
+        <a routerLink="/" class="btn btn-secondary">Back to Home</a>
+      }
     </div>
   }
 </div>

--- a/frontend/src/app/pages/premium/premium.component.ts
+++ b/frontend/src/app/pages/premium/premium.component.ts
@@ -19,8 +19,13 @@ export class PremiumComponent implements OnInit {
   loading = signal(true);
   error = signal<string | null>(null);
   processing = signal(false);
+  isAuthenticated = this.authService.isAuthenticated();
 
   ngOnInit(): void {
+    if (!this.isAuthenticated) {
+      this.loading.set(false);
+      return;
+    }
     this.authService.getMe().subscribe({
       error: () => {
         this.loading.set(false);


### PR DESCRIPTION
## Summary

The plans/pricing page was only accessible to authenticated users, hidden behind an auth guard. Unauthenticated users had no way to compare tiers before signing up.

### Changes
- Removed the `authGuard` from the `/premium` route so anyone can view the plans
- Updated the premium component to gracefully handle unauthenticated users (skip API calls, show static tier info)
- Added a "Plans" link in the nav bar for unauthenticated users (authenticated users already see "Account Tier")
- "Back to Dashboard" button shows "Back to Home" for unauthenticated users

Closes #14