### PR TITLE
fix: show Add Files option and filename for single-file uploads

### DIFF
--- a/frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/frontend/src/app/pages/dashboard/dashboard.component.html
@@ -25,7 +25,7 @@
           <div class="file-row">
             <div class="file-info">
               <h3 class="file-name">
-                @if (group.isGroup) {
+                @if (group.isGroup && group.files.length > 1) {
                   📁 {{ group.files.length }} files
                 } @else {
                   {{ group.files[0].original_filename }}
@@ -172,7 +172,7 @@
               </div>
 
               <!-- Add files (compact picker, auto-stages) -->
-              @if (group.isGroup && group.uploadGroup) {
+              @if (group.uploadGroup) {
                 <div class="expanded-section">
                   <h4>Add Files</h4>
                   <app-file-picker


### PR DESCRIPTION
## Summary

When a single file was uploaded, the dashboard showed it differently from multi-file uploads — no option to add more files/folders was available.

### Changes
- Show the original filename for single-file uploads instead of "📁 1 files"
- Show the "Add Files" picker whenever the upload has an `upload_group` (not only for multi-file groups), so users can add more files to any upload

Closes #25