### PR TITLE
fix: enforce tier limits and fix refresh expiry bug (#20)

### DIFF
--- a/frontend/src/app/components/upload-settings/upload-settings.component.html
+++ b/frontend/src/app/components/upload-settings/upload-settings.component.html
@@ -39,10 +39,9 @@
       [ngModel]="maxDownloads()"
       (ngModelChange)="maxDownloads.set($event)"
     >
-      <option [ngValue]="0">Unlimited</option>
-      <option [ngValue]="1">1</option>
-      <option [ngValue]="5">5</option>
-      <option [ngValue]="10">10</option>
+      @for (opt of maxDownloadsOptions(); track opt.value) {
+        <option [ngValue]="opt.value">{{ opt.label }}</option>
+      }
     </select>
   }
 </div>

--- a/frontend/src/app/components/upload-settings/upload-settings.component.ts
+++ b/frontend/src/app/components/upload-settings/upload-settings.component.ts
@@ -116,6 +116,14 @@ export class UploadSettingsComponent {
     return t === "free" || t === "premium";
   });
 
+  /** Available max download options for the select (temporary tier). */
+  maxDownloadsOptions = computed<{ value: number; label: string }[]>(() => {
+    return [
+      { label: "Unlimited", value: 0 },
+      { label: "1", value: 1 },
+    ];
+  });
+
   /** Whether user can add more passwords. */
   canAddPassword = computed(() => {
     const limit = this.maxPasswordsPerUpload();

--- a/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -37,7 +37,7 @@ export class DashboardComponent implements OnInit {
   userTier = signal("temporary");
 
   // Unified panel settings (bound to upload-settings component)
-  panelExpiryHours = signal(168);
+  panelExpiryHours = signal(72);
   panelMaxDownloads = signal(0);
 
   // Download stats for the expanded group

--- a/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -216,7 +216,8 @@ export class DashboardComponent implements OnInit {
           1,
           Math.ceil((new Date(ref.expires_at).getTime() - Date.now()) / (1000 * 60 * 60)),
         );
-        this.panelExpiryHours.set(hoursLeft > 0 ? hoursLeft : 168);
+        // Snap to nearest valid expiry option so the select shows a valid value
+        this.panelExpiryHours.set(this.snapToNearestExpiry(hoursLeft));
         this.panelMaxDownloads.set(ref.max_downloads ?? 0);
         // Load download stats if group has an upload_group
         if (group.uploadGroup) {
@@ -430,5 +431,21 @@ export class DashboardComponent implements OnInit {
 
   isExpired(expiresAt: string): boolean {
     return isExpired(expiresAt);
+  }
+
+  /** Snap a raw hours value to the nearest valid expiry option for the user's tier. */
+  private snapToNearestExpiry(hours: number): number {
+    const tier = this.userTier();
+    let options: number[];
+    if (tier === "premium") {
+      options = [1, 24, 72, 168, 336, 720];
+    } else if (tier === "free") {
+      options = [1, 24, 72, 168];
+    } else {
+      options = [24, 72];
+    }
+    return options.reduce((best, opt) =>
+      Math.abs(opt - hours) < Math.abs(best - hours) ? opt : best,
+    );
   }
 }

--- a/frontend/src/app/pages/home/home.component.ts
+++ b/frontend/src/app/pages/home/home.component.ts
@@ -72,8 +72,8 @@ export class HomeComponent {
   popupAuthError = signal<string | null>(null);
 
   // Upload settings
-  /** Default 7 days */
-  expiryHours = signal(168);
+  /** Default 3 days (valid for all tiers) */
+  expiryHours = signal(72);
   /** 0 = unlimited */
   maxDownloads = signal(0);
   /** Whether the upload is publicly accessible. */


### PR DESCRIPTION
## Fixes
- **Tier limits enforcement**: Temporary users could see 7-day expiry option and custom download input with options [0, 1, 5, 10] instead of the allowed [0, 1]
- **#20 Refresh expiry bug**: After expanding a group in the dashboard, the raw hours remaining was used as the expiry value, causing a blank dropdown and shifted expiry on refresh

## Changes
- Change default `expiryHours` from 168 (7 days) to 72 (3 days) — valid for all tiers including temporary
- Replace hardcoded max downloads select options `[0, 1, 5, 10]` with tier-appropriate `maxDownloadsOptions` computed property (temporary: `[0, 1]`)
- Snap dashboard panel expiry to nearest valid option for the user's tier when expanding a group
- Add `snapToNearestExpiry()` helper to dashboard component

Closes #20