### PR TITLE
feat: add transfer title and description (#26)

### DIFF
--- a/backend/alembic/versions/g1h2i3j4k5l6_add_title_description_to_group.py
+++ b/backend/alembic/versions/g1h2i3j4k5l6_add_title_description_to_group.py
@@ -1,0 +1,28 @@
+"""add title and description to upload group settings
+
+Revision ID: g1h2i3j4k5l6
+Revises: f1a2b3c4d5e6
+Create Date: 2025-01-01 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "g1h2i3j4k5l6"
+down_revision: str | None = "f1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("uploadgroupsettings", sa.Column("title", sa.String(), nullable=True))
+    op.add_column("uploadgroupsettings", sa.Column("description", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("uploadgroupsettings", "description")
+    op.drop_column("uploadgroupsettings", "title")

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -65,6 +65,8 @@ class UploadGroupSettings(SQLModel, table=True):
     upload_group: str = Field(primary_key=True, index=True)
     is_public: bool = Field(default=True)
     show_email_stats: bool = Field(default=False)
+    title: str | None = Field(default=None)
+    description: str | None = Field(default=None)
 
 
 class UploadPassword(SQLModel, table=True):

--- a/backend/src/routers/files.py
+++ b/backend/src/routers/files.py
@@ -218,6 +218,8 @@ async def _create_group_access(
     emails_json: str | None,
     show_email_stats: bool,
     user: User,
+    title: str | None = None,
+    description: str | None = None,
 ) -> tuple[UploadGroupSettings, int, int, list[tuple[str, str]]]:
     """Create group settings, passwords, and email recipients.
 
@@ -228,6 +230,8 @@ async def _create_group_access(
         upload_group=upload_group,
         is_public=is_public,
         show_email_stats=show_email_stats,
+        title=title[:200] if title else None,
+        description=description[:2000] if description else None,
     )
     session.add(group_settings)
 
@@ -306,6 +310,8 @@ async def upload_file(
     passwords: str | None = Form(None),
     emails: str | None = Form(None),
     show_email_stats: bool = Form(False),
+    title: str | None = Form(None),
+    description: str | None = Form(None),
 ) -> FileUploadResponse:
     # Get tier limits
     max_size_mb, _ = _get_limits(user.tier)
@@ -357,6 +363,8 @@ async def upload_file(
         emails,
         show_email_stats,
         user,
+        title=title,
+        description=description,
     )
 
     await session.commit()
@@ -403,6 +411,8 @@ async def upload_multiple_files(
     passwords: str | None = Form(None),
     emails: str | None = Form(None),
     show_email_stats: bool = Form(False),
+    title: str | None = Form(None),
+    description: str | None = Form(None),
 ) -> MultiFileUploadResponse:
     if not files:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No files provided")
@@ -472,6 +482,8 @@ async def upload_multiple_files(
         emails,
         show_email_stats,
         user,
+        title=title,
+        description=description,
     )
 
     await session.commit()
@@ -507,6 +519,8 @@ async def upload_multiple_files(
         files=[_to_response(fu, group_settings, pw_count, email_count) for fu in saved_uploads],
         upload_group=upload_group,
         total_size_bytes=total_size,
+        title=group_settings.title,
+        description=group_settings.description,
     )
 
 
@@ -539,6 +553,8 @@ async def get_group_info(
         is_public=group_settings.is_public if group_settings else True,
         has_passwords=pw_count > 0,
         has_email_recipients=email_count > 0,
+        title=group_settings.title if group_settings else None,
+        description=group_settings.description if group_settings else None,
     )
 
 
@@ -938,6 +954,8 @@ async def add_files_to_group(
         files=[_to_response(fu, gs, len(pws), len(ers)) for fu in saved_uploads],
         upload_group=upload_group,
         total_size_bytes=new_total,
+        title=gs.title if gs else None,
+        description=gs.description if gs else None,
     )
 
 
@@ -1000,6 +1018,18 @@ async def refresh_group(
         f.is_active = True
         session.add(f)
 
+    # Update group settings (title/description) on refresh
+    if body.title is not None or body.description is not None:
+        gs_stmt = select(UploadGroupSettings).where(UploadGroupSettings.upload_group == upload_group)
+        gs_result = await session.execute(gs_stmt)
+        gs_obj = gs_result.scalars().first()
+        if gs_obj:
+            if body.title is not None:
+                gs_obj.title = body.title[:200] if body.title else None
+            if body.description is not None:
+                gs_obj.description = body.description[:2000] if body.description else None
+            session.add(gs_obj)
+
     await session.commit()
     for f in files:
         await session.refresh(f)
@@ -1010,6 +1040,8 @@ async def refresh_group(
         files=[_to_response(f, gs, len(pws), len(ers)) for f in active_files],
         upload_group=upload_group,
         total_size_bytes=sum(f.file_size_bytes for f in active_files),
+        title=gs.title if gs else None,
+        description=gs.description if gs else None,
     )
 
 
@@ -1045,6 +1077,18 @@ async def edit_group(
             f.max_downloads = _resolve_max_downloads(body.max_downloads, user.tier)
         session.add(f)
 
+    # Update group settings (title/description)
+    if body.title is not None or body.description is not None:
+        gs_stmt = select(UploadGroupSettings).where(UploadGroupSettings.upload_group == upload_group)
+        gs_result = await session.execute(gs_stmt)
+        gs = gs_result.scalars().first()
+        if gs:
+            if body.title is not None:
+                gs.title = body.title[:200] if body.title else None
+            if body.description is not None:
+                gs.description = body.description[:2000] if body.description else None
+            session.add(gs)
+
     await session.commit()
     for f in files:
         await session.refresh(f)
@@ -1054,6 +1098,8 @@ async def edit_group(
         files=[_to_response(f, gs, len(pws), len(ers)) for f in files],
         upload_group=upload_group,
         total_size_bytes=sum(f.file_size_bytes for f in files),
+        title=gs.title if gs else None,
+        description=gs.description if gs else None,
     )
 
 

--- a/backend/src/schemas.py
+++ b/backend/src/schemas.py
@@ -67,6 +67,8 @@ class MultiFileUploadResponse(SQLModel):
     files: list[FileUploadResponse]
     upload_group: str
     total_size_bytes: int
+    title: str | None = None
+    description: str | None = None
 
 
 class UploadGroupInfoResponse(SQLModel):
@@ -78,6 +80,8 @@ class UploadGroupInfoResponse(SQLModel):
     is_public: bool = True
     has_passwords: bool = False
     has_email_recipients: bool = False
+    title: str | None = None
+    description: str | None = None
 
 
 class TransferInfoResponse(SQLModel):
@@ -115,11 +119,15 @@ class FileEditRequest(SQLModel):
 class GroupRefreshRequest(SQLModel):
     expiry_hours: int | None = None
     max_downloads: int | None = None
+    title: str | None = None
+    description: str | None = None
 
 
 class GroupEditRequest(SQLModel):
     expiry_hours: int | None = None
     max_downloads: int | None = None
+    title: str | None = None
+    description: str | None = None
 
 
 class AdminUserUpdateRequest(SQLModel):

--- a/frontend/src/app/api/endpoints/files/files.service.ts
+++ b/frontend/src/app/api/endpoints/files/files.service.ts
@@ -171,6 +171,12 @@ if(bodyUploadFileApiFilesUploadPost.show_email_stats !== undefined) {
 if(bodyUploadFileApiFilesUploadPost.altcha !== undefined) {
  formData.append(`altcha`, bodyUploadFileApiFilesUploadPost.altcha);
  }
+if(bodyUploadFileApiFilesUploadPost.title !== undefined && bodyUploadFileApiFilesUploadPost.title !== null) {
+ formData.append(`title`, bodyUploadFileApiFilesUploadPost.title);
+ }
+if(bodyUploadFileApiFilesUploadPost.description !== undefined && bodyUploadFileApiFilesUploadPost.description !== null) {
+ formData.append(`description`, bodyUploadFileApiFilesUploadPost.description);
+ }
 
     if (options?.observe === 'events') {
       return this.http.post<TData>(
@@ -229,6 +235,12 @@ if(bodyUploadMultipleFilesApiFilesUploadMultiplePost.show_email_stats !== undefi
  }
 if(bodyUploadMultipleFilesApiFilesUploadMultiplePost.altcha !== undefined) {
  formData.append(`altcha`, bodyUploadMultipleFilesApiFilesUploadMultiplePost.altcha);
+ }
+if(bodyUploadMultipleFilesApiFilesUploadMultiplePost.title !== undefined && bodyUploadMultipleFilesApiFilesUploadMultiplePost.title !== null) {
+ formData.append(`title`, bodyUploadMultipleFilesApiFilesUploadMultiplePost.title);
+ }
+if(bodyUploadMultipleFilesApiFilesUploadMultiplePost.description !== undefined && bodyUploadMultipleFilesApiFilesUploadMultiplePost.description !== null) {
+ formData.append(`description`, bodyUploadMultipleFilesApiFilesUploadMultiplePost.description);
  }
 
     if (options?.observe === 'events') {

--- a/frontend/src/app/api/model/bodyUploadFileApiFilesUploadPost.ts
+++ b/frontend/src/app/api/model/bodyUploadFileApiFilesUploadPost.ts
@@ -15,4 +15,6 @@ export interface BodyUploadFileApiFilesUploadPost {
   emails?: string | null;
   show_email_stats?: boolean;
   altcha?: string;
+  title?: string | null;
+  description?: string | null;
 }

--- a/frontend/src/app/api/model/bodyUploadMultipleFilesApiFilesUploadMultiplePost.ts
+++ b/frontend/src/app/api/model/bodyUploadMultipleFilesApiFilesUploadMultiplePost.ts
@@ -15,4 +15,6 @@ export interface BodyUploadMultipleFilesApiFilesUploadMultiplePost {
   emails?: string | null;
   show_email_stats?: boolean;
   altcha?: string;
+  title?: string | null;
+  description?: string | null;
 }

--- a/frontend/src/app/api/model/groupEditRequest.ts
+++ b/frontend/src/app/api/model/groupEditRequest.ts
@@ -9,4 +9,6 @@
 export interface GroupEditRequest {
   expiry_hours?: number | null;
   max_downloads?: number | null;
+  title?: string | null;
+  description?: string | null;
 }

--- a/frontend/src/app/api/model/groupRefreshRequest.ts
+++ b/frontend/src/app/api/model/groupRefreshRequest.ts
@@ -9,4 +9,6 @@
 export interface GroupRefreshRequest {
   expiry_hours?: number | null;
   max_downloads?: number | null;
+  title?: string | null;
+  description?: string | null;
 }

--- a/frontend/src/app/api/model/multiFileUploadResponse.ts
+++ b/frontend/src/app/api/model/multiFileUploadResponse.ts
@@ -11,4 +11,6 @@ export interface MultiFileUploadResponse {
   files: FileUploadResponse[];
   upload_group: string;
   total_size_bytes: number;
+  title?: string | null;
+  description?: string | null;
 }

--- a/frontend/src/app/api/model/uploadGroupInfoResponse.ts
+++ b/frontend/src/app/api/model/uploadGroupInfoResponse.ts
@@ -16,4 +16,6 @@ export interface UploadGroupInfoResponse {
   is_public?: boolean;
   has_passwords?: boolean;
   has_email_recipients?: boolean;
+  title?: string | null;
+  description?: string | null;
 }

--- a/frontend/src/app/components/upload-settings/upload-settings.component.html
+++ b/frontend/src/app/components/upload-settings/upload-settings.component.html
@@ -3,6 +3,32 @@
 }
 
 <div class="settings-row">
+  <label for="title">Title</label>
+  <input
+    type="text"
+    id="title"
+    class="form-input"
+    [ngModel]="title()"
+    (ngModelChange)="title.set($event)"
+    placeholder="Optional title"
+    maxlength="200"
+  />
+</div>
+
+<div class="settings-row">
+  <label for="description">Description</label>
+  <textarea
+    id="description"
+    class="form-input"
+    [ngModel]="description()"
+    (ngModelChange)="description.set($event)"
+    placeholder="Optional description"
+    maxlength="2000"
+    rows="2"
+  ></textarea>
+</div>
+
+<div class="settings-row">
   <label for="expiry">Expires after</label>
   <select id="expiry" [ngModel]="expiryHours()" (ngModelChange)="expiryHours.set($event)">
     @for (opt of expiryOptions(); track opt.value) {

--- a/frontend/src/app/components/upload-settings/upload-settings.component.scss
+++ b/frontend/src/app/components/upload-settings/upload-settings.component.scss
@@ -36,6 +36,24 @@ h3 {
       border-color: var(--color-input-focus);
     }
   }
+
+  input.form-input,
+  textarea.form-input {
+    @apply text-sm rounded-md border px-3 py-1.5 flex-1;
+    background: var(--color-input-bg, var(--color-card-bg));
+    border-color: var(--color-input-border);
+    color: var(--color-text);
+    min-width: 140px;
+
+    &:focus {
+      border-color: var(--color-input-focus);
+      outline: none;
+    }
+  }
+
+  textarea.form-input {
+    resize: vertical;
+  }
 }
 
 .input-with-toggle {

--- a/frontend/src/app/components/upload-settings/upload-settings.component.ts
+++ b/frontend/src/app/components/upload-settings/upload-settings.component.ts
@@ -39,6 +39,12 @@ export class UploadSettingsComponent {
   /** Whether email recipients can see download stats. */
   showEmailStats = model(false);
 
+  /** Transfer title. */
+  title = model("");
+
+  /** Transfer description. */
+  description = model("");
+
   /** Whether to show the heading. */
   showHeading = input(true);
 

--- a/frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/frontend/src/app/pages/dashboard/dashboard.component.html
@@ -190,6 +190,8 @@
                   [tier]="userTier()"
                   [(expiryHours)]="panelExpiryHours"
                   [(maxDownloads)]="panelMaxDownloads"
+                  [(title)]="panelTitle"
+                  [(description)]="panelDescription"
                   [showHeading]="false"
                   [showAccessControl]="false"
                 />

--- a/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -38,8 +38,8 @@ export class DashboardComponent implements OnInit {
 
   // Unified panel settings (bound to upload-settings component)
   panelExpiryHours = signal(168);
-  panelMaxDownloads = signal(0);
-
+  panelMaxDownloads = signal(0);  panelTitle = signal("");
+  panelDescription = signal("");
   // Download stats for the expanded group
   groupStats = signal<DownloadStatsResponse | null>(null);
   statsLoading = signal(false);
@@ -218,9 +218,10 @@ export class DashboardComponent implements OnInit {
         );
         this.panelExpiryHours.set(hoursLeft > 0 ? hoursLeft : 168);
         this.panelMaxDownloads.set(ref.max_downloads ?? 0);
-        // Load download stats if group has an upload_group
+        // Load download stats and group info (for title/description)
         if (group.uploadGroup) {
           this.loadGroupStats(group.uploadGroup);
+          this.loadGroupInfo(group.uploadGroup);
         }
       }
     }
@@ -246,6 +247,8 @@ export class DashboardComponent implements OnInit {
           .editGroup(group.uploadGroup, {
             expiry_hours: this.panelExpiryHours(),
             max_downloads: this.panelMaxDownloads() || undefined,
+            title: this.panelTitle() || null,
+            description: this.panelDescription() || null,
           })
           .subscribe({
             error: () => {
@@ -335,6 +338,8 @@ export class DashboardComponent implements OnInit {
           .refreshGroup(group.uploadGroup, {
             expiry_hours: this.panelExpiryHours(),
             max_downloads: this.panelMaxDownloads() || undefined,
+            title: this.panelTitle() || null,
+            description: this.panelDescription() || null,
           })
           .subscribe({
             error: () => {
@@ -420,6 +425,15 @@ export class DashboardComponent implements OnInit {
       next: (stats) => {
         this.groupStats.set(stats);
         this.statsLoading.set(false);
+      },
+    });
+  }
+
+  private loadGroupInfo(uploadGroup: string): void {
+    this.fileService.getGroupInfo(uploadGroup).subscribe({
+      next: (info) => {
+        this.panelTitle.set(info.title ?? "");
+        this.panelDescription.set(info.description ?? "");
       },
     });
   }

--- a/frontend/src/app/pages/download/download.component.html
+++ b/frontend/src/app/pages/download/download.component.html
@@ -74,9 +74,21 @@
       @if (!needsPassword()) {
         <div class="card file-card">
           <div class="file-icon">📦</div>
-          <h2>{{ group.file_count }} {{ group.file_count === 1 ? "File" : "Files" }}</h2>
+          @if (group.title) {
+            <h2>{{ group.title }}</h2>
+          } @else {
+            <h2>{{ group.file_count }} {{ group.file_count === 1 ? "File" : "Files" }}</h2>
+          }
+          @if (group.description) {
+            <p class="transfer-description">{{ group.description }}</p>
+          }
           <div class="file-meta">
             <span>Total size: {{ formatSize(group.total_size_bytes) }}</span>
+            @if (group.title) {
+              <span
+                >{{ group.file_count }} {{ group.file_count === 1 ? "file" : "files" }}</span
+              >
+            }
           </div>
           @if (group.will_zip) {
             <div class="alert alert-info zip-info">

--- a/frontend/src/app/pages/download/download.component.scss
+++ b/frontend/src/app/pages/download/download.component.scss
@@ -45,6 +45,11 @@
   }
 }
 
+.transfer-description {
+  @apply text-sm mb-4 whitespace-pre-line;
+  color: var(--color-text-secondary);
+}
+
 .file-meta {
   @apply flex flex-col gap-1 text-sm mb-6;
   color: var(--color-text-secondary);

--- a/frontend/src/app/pages/home/home.component.html
+++ b/frontend/src/app/pages/home/home.component.html
@@ -90,6 +90,8 @@
             [(passwords)]="passwords"
             [(emails)]="emails"
             [(showEmailStats)]="showEmailStats"
+            [(title)]="title"
+            [(description)]="description"
             [maxPasswordsPerUpload]="maxPasswordsPerUpload()"
             [maxEmailsPerUpload]="maxEmailsPerUpload()"
           />

--- a/frontend/src/app/pages/home/home.component.ts
+++ b/frontend/src/app/pages/home/home.component.ts
@@ -84,6 +84,10 @@ export class HomeComponent {
   emails = signal<string[]>([]);
   /** Whether email recipients can see download stats. */
   showEmailStats = signal(false);
+  /** Transfer title. */
+  title = signal("");
+  /** Transfer description. */
+  description = signal("");
 
   altchaHintText = computed(() => {
     switch (this.altchaState()) {
@@ -311,6 +315,8 @@ export class HomeComponent {
           passwords: this.passwords().filter((p) => p.password),
           emails: this.emails().filter((e) => e.trim()),
           showEmailStats: this.showEmailStats(),
+          title: this.title(),
+          description: this.description(),
         })
         .subscribe({
           error: (err) => {
@@ -344,6 +350,8 @@ export class HomeComponent {
         passwords: this.passwords().filter((p) => p.password),
         emails: this.emails().filter((e) => e.trim()),
         showEmailStats: this.showEmailStats(),
+        title: this.title(),
+        description: this.description(),
       })
       .subscribe({
         error: (err) => {

--- a/frontend/src/app/services/file.service.ts
+++ b/frontend/src/app/services/file.service.ts
@@ -36,6 +36,8 @@ export interface UploadAccessOptions {
   passwords?: { label: string; password: string }[];
   emails?: string[];
   showEmailStats?: boolean;
+  title?: string;
+  description?: string;
 }
 
 @Injectable({
@@ -66,6 +68,8 @@ export class FileService {
         emails:
           options?.emails && options.emails.length > 0 ? JSON.stringify(options.emails) : undefined,
         show_email_stats: options?.showEmailStats ?? false,
+        title: options?.title || undefined,
+        description: options?.description || undefined,
       },
       { observe: "events", reportProgress: true },
     );
@@ -117,6 +121,8 @@ export class FileService {
         emails:
           options?.emails && options.emails.length > 0 ? JSON.stringify(options.emails) : undefined,
         show_email_stats: options?.showEmailStats ?? false,
+        title: options?.title || undefined,
+        description: options?.description || undefined,
       },
       { observe: "events", reportProgress: true },
     );


### PR DESCRIPTION
## Feature
Add transfer title and description support, similar to WeTransfer.

Users can now set an optional title and description when uploading files. These are displayed on the download page and can be edited from the dashboard.

## Changes

### Backend
- Add `title` and `description` fields to `UploadGroupSettings` model
- Create database migration `g1h2i3j4k5l6` for new columns
- Update `/upload` and `/upload-multiple` endpoints to accept `title` and `description` form fields
- Update `/group/{upload_group}` info endpoint to return title/description
- Update `PATCH /group/{upload_group}` (edit) to support title/description changes
- Update `POST /group/{upload_group}/refresh` to support title/description changes
- Input is truncated server-side (title: 200 chars, description: 2000 chars)

### Frontend
- Add `title` and `description` model signals to `upload-settings` component
- Add title input and description textarea to upload settings UI
- Pass title/description through home page upload flow to API
- Display title as heading and description as body text on the download page
- Load and bind title/description in dashboard panel for editing
- Update all generated API types (`MultiFileUploadResponse`, `UploadGroupInfoResponse`, `GroupEditRequest`, `GroupRefreshRequest`, body types)

Closes #26