### PR TITLE
Require explicit cloud deploy enablement

### DIFF
--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -41,14 +41,15 @@ jobs:
     runs-on: ubuntu-24.04
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' &&
-        (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/heads/release/') ||
-          github.ref_type == 'tag')) ||
-      (github.event_name == 'workflow_run' &&
-        github.event.workflow_run.conclusion == 'success' &&
-        (github.event.workflow_run.head_branch == 'main' ||
-          startsWith(github.event.workflow_run.head_branch, 'release/')))
+      (vars.SENDR_AUTO_DEPLOY_ENABLED == 'true' &&
+        ((github.event_name == 'push' &&
+          (github.ref == 'refs/heads/main' ||
+            startsWith(github.ref, 'refs/heads/release/') ||
+            github.ref_type == 'tag')) ||
+        (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          (github.event.workflow_run.head_branch == 'main' ||
+            startsWith(github.event.workflow_run.head_branch, 'release/')))))
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || github.ref_type == 'tag' && 'prod' || startsWith(github.ref, 'refs/heads/release/') && 'staging' || 'dev' }}
     env:
       DEPLOY_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || github.ref_type == 'tag' && 'prod' || startsWith(github.ref, 'refs/heads/release/') && 'staging' || startsWith(github.event.workflow_run.head_branch, 'release/') && 'staging' || 'dev' }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -63,7 +63,12 @@ jobs:
     name: Apply
     runs-on: ubuntu-24.04
     needs: validate
-    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || github.ref_type == 'tag'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (vars.SENDR_AUTO_DEPLOY_ENABLED == 'true' &&
+        (github.ref == 'refs/heads/main' ||
+          startsWith(github.ref, 'refs/heads/release/') ||
+          github.ref_type == 'tag'))
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || github.ref_type == 'tag' && 'prod' || startsWith(github.ref, 'refs/heads/release/') && 'staging' || 'dev' }}
     defaults:
       run:

--- a/terraform/ENVIRONMENTS_GUIDE.md
+++ b/terraform/ENVIRONMENTS_GUIDE.md
@@ -10,16 +10,22 @@ Infrastruktura jest obsługiwana przez jeden wspólny workflow Terraform: `.gith
 | --- | --- | --- |
 | Pull request z plikami Terraform | brak | `terraform fmt`, `terraform init -backend=false`, `terraform validate` |
 | `DO-implementation` | brak | walidacja Terraform bez `apply` i bez deploymentu Kubernetes |
-| `main` | `dev` | Terraform `apply`, build obrazów i deployment Kubernetes |
-| `release/**` | `staging` | Terraform `apply`, build obrazów i deployment Kubernetes |
-| tag `v*` | `prod` | Terraform `apply` i deployment wydania produkcyjnego |
-| `workflow_dispatch` | wybrane ręcznie | ręczne uruchomienie dla `dev`, `staging` albo `prod` |
+| `main` | `dev` | build obrazów i walidacja; `apply` oraz deployment tylko gdy `SENDR_AUTO_DEPLOY_ENABLED=true` |
+| `release/**` | `staging` | build obrazów i walidacja; `apply` oraz deployment tylko gdy `SENDR_AUTO_DEPLOY_ENABLED=true` |
+| tag `v*` | `prod` | build obrazów i walidacja; `apply` oraz deployment tylko gdy `SENDR_AUTO_DEPLOY_ENABLED=true` |
+| `workflow_dispatch` | wybrane ręcznie | ręczne uruchomienie `apply` i deploymentu dla `dev`, `staging` albo `prod` |
 
 `DO-implementation` jest gałęzią integracyjną. Może budować obrazy i walidować Terraform, ale nie powinna zużywać sekretów produkcyjnych ani wykonywać zmian w chmurze.
 
+## Włączanie automatycznych deploymentów
+
+Realne zmiany w DigitalOcean są domyślnie bezpiecznie zatrzymane po walidacji, dopóki repozytorium nie ma poprawnych sekretów DigitalOcean i Spaces. Aby włączyć automatyczny `apply` i deployment z gałęzi/tagów, ustaw zmienną repozytorium GitHub `SENDR_AUTO_DEPLOY_ENABLED` na `true` w **Settings** -> **Secrets and variables** -> **Actions** -> **Variables**.
+
+Ręczne uruchomienia przez `workflow_dispatch` zawsze wymagają sekretów wybranego środowiska, ale nie wymagają tej zmiennej.
+
 ## DEV
 
-Środowisko `dev` jest aktualizowane z gałęzi `main` albo ręcznie przez `workflow_dispatch` z opcją `dev`.
+Środowisko `dev` jest aktualizowane ręcznie przez `workflow_dispatch` z opcją `dev`. Push na `main` może wdrażać automatycznie tylko po ustawieniu `SENDR_AUTO_DEPLOY_ENABLED=true`.
 
 ```bash
 git checkout main
@@ -30,7 +36,7 @@ git push origin main
 
 ## STAGING
 
-Środowisko `staging` jest aktualizowane z gałęzi `release/**` albo ręcznie przez `workflow_dispatch` z opcją `staging`.
+Środowisko `staging` jest aktualizowane ręcznie przez `workflow_dispatch` z opcją `staging`. Gałęzie `release/**` mogą wdrażać automatycznie tylko po ustawieniu `SENDR_AUTO_DEPLOY_ENABLED=true`.
 
 ```bash
 git checkout main
@@ -40,7 +46,7 @@ git push origin release/v1.2.0
 
 ## PROD
 
-Środowisko `prod` jest aktualizowane przez tagi `v*` albo ręcznie przez `workflow_dispatch` z opcją `prod`.
+Środowisko `prod` jest aktualizowane ręcznie przez `workflow_dispatch` z opcją `prod`. Tagi `v*` mogą wdrażać automatycznie tylko po ustawieniu `SENDR_AUTO_DEPLOY_ENABLED=true`.
 
 ```bash
 git checkout main

--- a/terraform/SETUP.md
+++ b/terraform/SETUP.md
@@ -61,6 +61,8 @@ W repozytorium (Settings -> Secrets and variables -> Actions) dodaj:
 
 Sekrety produkcyjne najlepiej dodać jako sekrety środowiska GitHub (`dev`, `staging`, `prod`), aby wdrożenia mogły korzystać z innych wartości dla każdego środowiska.
 
+Automatyczne deploymenty z gałęzi/tagów są wyłączone, dopóki zmienna repozytorium `SENDR_AUTO_DEPLOY_ENABLED` nie ma wartości `true`. Ręczne uruchomienie przez `workflow_dispatch` nadal działa po podaniu poprawnych sekretów.
+
 ---
 
 ## ⚙️ ETAP 3: Konfiguracja Środowisk
@@ -73,9 +75,9 @@ Backend stanu Terraform używa `terraform/environments/*/backend.conf`. W tych p
 
 ## 🚀 ETAP 4: Wdrożenie (GitFlow)
 
-- **DEV:** Push na `main` lub `DO-implementation`.
-- **STAGING:** Push na gałąź `release/*`.
-- **PROD:** Push Taga wersji (np. `v1.0.0`).
+- **DEV:** Ręcznie uruchom `.github/workflows/terraform.yml` i `.github/workflows/deploy-k8s.yml` z opcją `dev`; push na `main` wdraża automatycznie tylko gdy `SENDR_AUTO_DEPLOY_ENABLED=true`.
+- **STAGING:** Ręczne uruchomienie z opcją `staging`; gałąź `release/*` wdraża automatycznie tylko gdy `SENDR_AUTO_DEPLOY_ENABLED=true`.
+- **PROD:** Ręczne uruchomienie z opcją `prod`; tag wersji (np. `v1.0.0`) wdraża automatycznie tylko gdy `SENDR_AUTO_DEPLOY_ENABLED=true`.
 
 ---
 


### PR DESCRIPTION
Prevents automatic DigitalOcean apply/deploy jobs from running with invalid or unverified cloud credentials.

Summary:
- Keeps Terraform validation and Docker builds automatic.
- Allows Terraform apply and Kubernetes deployment through `workflow_dispatch`.
- Allows automatic branch/tag deployment only when the repo variable `SENDR_AUTO_DEPLOY_ENABLED` is set to `true`.
- Updates Terraform deployment docs with the new safety gate.

Local validation:
- `actionlint` passed for Terraform and deploy workflows.
- `terraform fmt -check -recursive`, `terraform init -backend=false`, and `terraform validate -no-color` passed.